### PR TITLE
feat(processors): use async processors

### DIFF
--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -13,7 +13,7 @@ export class Builder {
      * @param {IFixture} fixture
      * @return {any}
      */
-    build(fixture: IFixture) {
+    async build(fixture: IFixture) {
         const repository = this.connection.getRepository(fixture.entity);
         const entity = repository.create();
         let data = this.parser.parse(fixture.data, fixture, this.entities);
@@ -48,7 +48,7 @@ export class Builder {
 
             /* istanbul ignore else */
             if (typeof processorInstance.preProcess === 'function') {
-                data = processorInstance.preProcess(fixture.name, data);
+                data = await Promise.resolve(processorInstance.preProcess(fixture.name, data));
             }
 
             Object.assign(entity, data);
@@ -68,7 +68,7 @@ export class Builder {
 
             /* istanbul ignore else */
             if (typeof processorInstance.postProcess === 'function') {
-                processorInstance.postProcess(fixture.name, entity);
+                await Promise.resolve(processorInstance.postProcess(fixture.name, entity));
             }
         } else {
             Object.assign(entity, data);

--- a/src/Builder.ts
+++ b/src/Builder.ts
@@ -48,7 +48,7 @@ export class Builder {
 
             /* istanbul ignore else */
             if (typeof processorInstance.preProcess === 'function') {
-                data = await Promise.resolve(processorInstance.preProcess(fixture.name, data));
+                data = await processorInstance.preProcess(fixture.name, data);
             }
 
             Object.assign(entity, data);
@@ -68,7 +68,7 @@ export class Builder {
 
             /* istanbul ignore else */
             if (typeof processorInstance.postProcess === 'function') {
-                await Promise.resolve(processorInstance.postProcess(fixture.name, entity));
+                await processorInstance.postProcess(fixture.name, entity);
             }
         } else {
             Object.assign(entity, data);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,7 @@ createConnection(
         bar.start(fixtures.length, 0, { name: '' });
 
         for (const fixture of fixturesIterator(fixtures)) {
-            const entity = builder.build(fixture);
+            const entity = await Promise.resolve(builder.build(fixture));
 
             try {
                 bar.increment(1, { name: fixture.name });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -105,7 +105,7 @@ createConnection(
         bar.start(fixtures.length, 0, { name: '' });
 
         for (const fixture of fixturesIterator(fixtures)) {
-            const entity = await Promise.resolve(builder.build(fixture));
+            const entity = await builder.build(fixture);
 
             try {
                 bar.increment(1, { name: fixture.name });

--- a/src/interface/IProcessor.ts
+++ b/src/interface/IProcessor.ts
@@ -1,4 +1,4 @@
 export interface IProcessor<T> {
-    preProcess?(name: string, object: any): any;
-    postProcess?(name: string, object: T): void;
+    preProcess?(name: string, object: any): any | Promise<any>;
+    postProcess?(name: string, object: T): void | Promise<void>;
 }


### PR DESCRIPTION
**Description**
When using pre-processors I want to be able to use asynchronous functions.

**Solution**
Allow the usage of async processor functions.

**Example**
two entity types:
- User (id: uuid, name: string, roles: Role[])
- Role (id: number, name: string)

I want to be able to associate roles to a user by role name:

```
entity: User
parameters: {}
processor: ../processors/UserProcessor
items:
  user0:
    name: 'Jean-Marc Arsan'
    roles:
      - 'Admin'
      - 'User'
```

In this case, I need to first fetch the roles by name and return the object as follows:

```
import {IProcessor} from 'typeorm-fixtures-cli';
import { Role } from '../../api/models/Role';
import { User } from '../../api/models/User';

export default class UserProcessor implements IProcessor<User> {

   public async preProcess(name: string, obj: { [key: string]: any }): Promise<any> {
    const { roles: roleNames = []} = obj;
        if (roleNames.length > 0) {
            const where = roleNames.map((roleName: string): { name: string} => ({ name: roleName }));
            const roles = await Role.find({ where });
            const user = { ...obj, roles };
            return user;
        }
    return obj;
   }
}
```