### PR TITLE
Set createdAt and updateAt if specified in fixture

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -110,6 +110,23 @@ createConnection(
             try {
                 bar.increment(1, { name: fixture.name });
                 await getRepository(entity.constructor.name).save(entity);
+
+                // If the fixtures set the createdAt or updatedAt timestamps, we need to
+                // update them manually because TypeORM overwrites them on save().
+                const timestamps: any = {};
+                if (fixture.data.createdAt) {
+                    timestamps.createdAt = fixture.data.createdAt;
+                }
+                if (fixture.data.updateAt) {
+                    timestamps.updatedAt = fixture.data.updatedAt;
+                }
+
+                if (Object.keys(timestamps).length > 0) {
+                    await getRepository(entity.constructor.name).update(
+                        entity.id,
+                        timestamps
+                    );
+                }
             } catch (e) {
                 bar.stop();
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -117,7 +117,7 @@ createConnection(
                 if (fixture.data.createdAt) {
                     timestamps.createdAt = fixture.data.createdAt;
                 }
-                if (fixture.data.updateAt) {
+                if (fixture.data.updatedAt) {
                     timestamps.updatedAt = fixture.data.updatedAt;
                 }
 


### PR DESCRIPTION
This feature is used in a project I am working on implemented by another team member.
I might be wrong but I thought it would be a good addition to the cli command.

This could be useful to preserve data creation dates for example instead of having another datefield to keep track of.