### PR TITLE
fix: getting repository from established connection rather than default

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,7 +109,7 @@ createConnection(
 
             try {
                 bar.increment(1, { name: fixture.name });
-                await getRepository(entity.constructor.name).save(entity);
+                await connection.getRepository(entity.constructor.name).save(entity);
             } catch (e) {
                 bar.stop();
 


### PR DESCRIPTION
Connection is made with connection parameter but is ignored when saving the newly created entity in the CLI resulting in default connection not found errors. This should fix that issue.

Not done an awful lot of open sourcing before so if this isn't the best way to suggests changes I'd love to know!

Thanks.