### PR TITLE
Fix CLI --require flag not taking array of modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,13 @@ Options:
   --no-color                 Disable color
 ```
 
+##### Require multiple additional modules
+If you're using multiple modules at once (e.g. ts-node and tsconfig-paths)
+you have the ability to require these modules with multiple require flags. For example:
+```
+fixtures ./fixtures --config ./typeorm.config.ts --sync --require=ts-node/register --require=tsconfig-paths/register
+```
+
 ## Samples
 
 - [typeorm-fixtures-sample](https://github.com/RobinCK/typeorm-fixtures-sample)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,10 +35,10 @@ commander.parse(process.argv);
 const argv = yargsParser(process.argv.slice(2));
 
 if (argv.require) {
-    const requires = Array.isArray(argv) ? argv : [argv];
+    const requires = Array.isArray(argv.require) ? argv.require : [argv.require];
 
     for (const req of requires) {
-        require(resolveFrom.silent(process.cwd(), commander.require) || commander.require);
+        require(resolveFrom.silent(process.cwd(), req) || req);
     }
 }
 


### PR DESCRIPTION
**Problem:**
Require flag doesn't take multiple modules. It always takes the last flag set module and ignores the first. With this fix it works now

**Command that I've tested with**
```
fixtures ./src/fixtures --config ./src/config/typeorm.config.ts --sync --require=ts-node/register --require=tsconfig-paths/register
```

> I'm new to community PR's, so if you see something dumb that I did (codestyle, readme structure etc) please don't judge too much 😄