### PR TITLE
Add support for export default

### DIFF
--- a/src/util/createConnection.ts
+++ b/src/util/createConnection.ts
@@ -4,6 +4,6 @@ export async function createConnection(config: object, connectionName: string): 
     const options = await new ConnectionOptionsReader(config).get(connectionName);
 
     return getConnectionManager()
-        .create(options)
+        .create(options.default ? options.default : options)
         .connect();
 }


### PR DESCRIPTION
This allows the use of export default when reading from ormconfig.ts, without breaking current functionality (as there is no option called default)