### PR TITLE
Upgrade joi to @hapi/joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "yaml-lint": "^1.2.4"
   },
   "dependencies": {
-    "@types/joi": "^14.3.3",
+    "@hapi/joi": "^16.1.8",
+    "@types/hapi__joi": "^16.0.3",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
     "class-transformer": "^0.2.3",
@@ -83,7 +84,6 @@
     "ejs": "^2.6.2",
     "faker": "^4.1.0",
     "glob": "^7.1.4",
-    "joi": "^14.3.1",
     "js-yaml": "3.13.1",
     "lodash": "^4.17.14",
     "opencollective-postinstall": "^2.0.2",

--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
-import * as Joi from 'joi';
 import * as loaders from './loaders';
 import { IFixturesConfig, ILoader } from './interface';
 import { jFixturesSchema } from './schema';
@@ -39,7 +38,7 @@ export class Loader {
             /* istanbul ignore else */
             if (loader) {
                 const fixtureConfig: IFixturesConfig = loader.load(file);
-                const { error } = Joi.validate(fixtureConfig, jFixturesSchema);
+                const { error } = jFixturesSchema.validate(fixtureConfig);
 
                 if (error) {
                     throw new Error(`Invalid fixtures config. File "${file}"`);

--- a/src/schema/jFixturesSchema.ts
+++ b/src/schema/jFixturesSchema.ts
@@ -1,4 +1,4 @@
-import * as Joi from 'joi';
+import * as Joi from '@hapi/joi';
 
 export const jFixturesSchema = Joi.object().keys({
     entity: Joi.string()


### PR DESCRIPTION
Dear @RobinCK ,

this PR upgrade `joi 14.x` to `@hapi/joi 16.x`.
When installing `typeorm-fixtures` a deprecation warning (as described in #24 ) is shown.

This PR addresses this issue!

All test passes!

All the best