### PR TITLE
feat: parses parameters from process.env

### DIFF
--- a/src/parsers/ParameterParser.ts
+++ b/src/parsers/ParameterParser.ts
@@ -38,7 +38,16 @@ export class ParameterParser implements IParser {
                 const parameterValue = get(fixture.parameters, parameter);
 
                 if (parameterValue === undefined) {
-                    throw new Error(`Unknown parameter "${parameter}" in ${fixture.name}`);
+                    if (parameter.startsWith('process.env')) {
+                        const key = parameter.replace('process.env.', '');
+                        if (key in process.env) {
+                            result.push(process.env[key]);
+                        } else {
+                            throw new Error(`Unkown environment variable "${parameter}" in ${fixture.name}`);
+                        }
+                    } else {
+                        throw new Error(`Unknown parameter "${parameter}" in ${fixture.name}`);
+                    }
                 }
 
                 result.push(parameterValue);

--- a/test/unit/parsers/ParameterParser.test.ts
+++ b/test/unit/parsers/ParameterParser.test.ts
@@ -45,4 +45,59 @@ describe('Parameter parser', () => {
             }),
         ).to.throw('Unknown parameter "boo" in name');
     });
+
+    it('should be taken from process.env', () => {
+        process.env.FOOBAR = 'foo';
+        const parser = new ParameterParser();
+
+        const result = parser.parse('<{process.env.FOOBAR}>', {
+            parameters: {
+                foo: 'boo',
+            },
+            entity: 'test',
+            name: 'name',
+            dependencies: [],
+            data: {},
+        });
+
+        expect(result).to.equal('foo');
+    });
+
+    it('should throw on unknown env variable', () => {
+        delete process.env.FOOBAR;
+        const parser = new ParameterParser();
+
+        expect(() =>
+            parser.parse('<{process.env.FOOBAR}>', {
+                parameters: {
+                    foo: 'boo',
+                },
+                entity: 'test',
+                name: 'name',
+                dependencies: [],
+                data: {},
+            }),
+        ).to.throw('Unkown environment variable "process.env.FOOBAR" in name');
+    });
+
+    it('should prefer explicit parameters to env variables', () => {
+        process.env.FOOBAR = 'foo';
+        const parser = new ParameterParser();
+
+        const result = parser.parse('<{process.env.FOOBAR}>', {
+            parameters: {
+                process: {
+                    env: {
+                        FOOBAR: 'bar',
+                    },
+                },
+            },
+            entity: 'test',
+            name: 'name',
+            dependencies: [],
+            data: {},
+        });
+
+        expect(result).to.equal('bar');
+    });
 });


### PR DESCRIPTION
This PR allows to use parameter substitution from `process.env` like this: `id: '<{process.env.ADMIN_USER_ID}>'`

Related #101 