### PR TITLE
Update parser to allow escape faker.js curly brace expansion #117

### DIFF
--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -27,6 +27,11 @@ export class Parser implements IDataParser {
                         entityRawData[key] = parser.parse(value, fixture, entities);
                     }
                 }
+                
+                // Process escape sequences
+                if (typeof entityRawData[key] === 'string') {
+                    entityRawData[key] = this.processEscapes(entityRawData[key]);
+                }
             }
 
             /* istanbul ignore else */
@@ -57,7 +62,7 @@ export class Parser implements IDataParser {
      *
      * @param {string} value
      */
-    public unescapeValue(value: string) {
+    public processEscapes(value: string) {
         let state = 'unescaped';
         let unescapedValue = '';
 

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -54,7 +54,7 @@ export class Parser implements IDataParser {
      * {{name.firstName}} === 'John'
      *
      * // Escape curly braces, no faker interpolation
-     * %{%name.firstName%}%} === '%{%{name.firstName%}%}'
+     * %{%{name.firstName%}%} === '{{name.firstName}}'
      *
      * // Escape %
      * %%{{name.firstName}}%% === '%John%'


### PR DESCRIPTION
Process `%` escape sequence to escape curly braces to prevent `faker` interpolation.

For example:

```
// Faker interpolation
{{name.firstName}} === 'John'

// Escape curly braces, no faker interpolation
%{%{name.firstName%}%} === '{{name.firstName}}'

// Escape %
%%{{name.firstName}}%% === '%John%'
```