### PR TITLE
fix: table names with underscores cannot be loaded

### DIFF
--- a/src/schema/jFixturesSchema.ts
+++ b/src/schema/jFixturesSchema.ts
@@ -1,7 +1,7 @@
 import * as Joi from '@hapi/joi';
 
 export const jFixturesSchema = Joi.object().keys({
-    entity: Joi.string().alphanum().min(1).required(),
+    entity: Joi.string().min(1).required(),
     parameters: Joi.object(),
     processor: Joi.string(),
     items: Joi.object().required(),


### PR DESCRIPTION
Fixes #150 

Library should not verify table naming convention. If a table contains underscores then the entity cannot be loaded. 