### PR TITLE
fix: Recognize EJS over multiple lines

### DIFF
--- a/src/parsers/EjsParser.ts
+++ b/src/parsers/EjsParser.ts
@@ -11,7 +11,7 @@ export class EjsParser implements IParser {
      * @type {RegExp}
      */
     private get regExp() {
-        return /<%(.+?)%>/gm;
+        return /<%(.+?)%>/gms;
     }
 
     /**


### PR DESCRIPTION
The `s` flag allows `.` to match newlines so that if the value only contains a multiline EJS expression it will still be rendered by EJS. It allows this to work:

```
    status: >-
      <%= 
        [ 
          'pending_approval',
          'approved',
          'rejected',
        ][ ~~(Math.random()*3) ]
      %>
```