### PR TITLE
Fix non-apply of locale parameter to faker.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,19 @@ items:
         - foo
 ```
 
+#### Defining a locale parameter for [faker.js](https://github.com/marak/Faker.js/)
+
+You can add the `locale` key in your fixture root document to define the used locale in faker.js.
+
+```yaml
+entity: User
+locale: fr
+items:
+  user{1..10}:
+    ...
+```
+
+
 ### EJS templating
 
 This library integrates with the [EJS](https://github.com/mde/ejs)

--- a/src/Resolver.ts
+++ b/src/Resolver.ts
@@ -11,7 +11,7 @@ export class Resolver {
      * @return {IFixture[]}
      */
     resolve(fixtureConfigs: IFixturesConfig[]): IFixture[] {
-        for (const { entity, items, parameters, processor, resolvedFields } of fixtureConfigs) {
+        for (const { entity, items, parameters, processor, resolvedFields, locale } of fixtureConfigs) {
             for (const [mainReferenceName, propertyList] of Object.entries(items)) {
                 const rangeRegExp = /^([\w-_]+)\{(\d+)\.\.(\d+)\}$/gm;
                 let referenceNames: string[] = [];
@@ -39,6 +39,7 @@ export class Resolver {
                         name: name,
                         resolvedFields,
                         data,
+                        locale,
                         dependencies: this.resolveDependencies(name, data),
                     });
                 }

--- a/src/Resolver.ts
+++ b/src/Resolver.ts
@@ -11,7 +11,7 @@ export class Resolver {
      * @return {IFixture[]}
      */
     resolve(fixtureConfigs: IFixturesConfig[]): IFixture[] {
-        for (const { entity, items, parameters, processor, resolvedFields, locale } of fixtureConfigs) {
+        for (const { entity, items, locale, parameters, processor, resolvedFields } of fixtureConfigs) {
             for (const [mainReferenceName, propertyList] of Object.entries(items)) {
                 const rangeRegExp = /^([\w-_]+)\{(\d+)\.\.(\d+)\}$/gm;
                 let referenceNames: string[] = [];


### PR DESCRIPTION
In 1.8.0, the ability of specifiying the locale used in faker.js has been implemented, but doesn't apply automatically (and isn't documented).

I've haven't managed to make it work with the given example:
```ts
for (const fixture of fixturesIterator(fixtures)) {
  const entity = await builder.build(fixture);
  await getRepository(entity.constructor.name).save(entity);
}
```
with the given fixture:
```yaml
entity: User
locale: fr
items:
  user{1..10}:
    firstName: '{{name.firstName}}'
    lastName: '{{name.lastName}}'
    birthDate: '{{date.past}}'
    email: '{{internet.email}}'
    phone: '{{phone.phoneNumber}}'
    country: France
    city: '{{address.city}}'
```

I've added the line `fixture.locale = 'fr';` before `builder.build` line, and it works fine (so I've assumed `locale` parameter from yml file wasn't read properly).

This PR fixes the missing `locale` property of a `IFixture`, and add documentation in README.md to apply a locale for faker.js.