### PR TITLE
docs: update faker.js syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ items:
     fullname: '{{name.firstName}} {{name.lastName}}'
     birthDate: '{{date.past}}'
     email: '{{internet.email}}'
-    favoriteNumber: '{{random.number}}'
+    favoriteNumber: '{{datatype.number}}'
     __call:
       setPassword:
         - foo


### PR DESCRIPTION
use `datatype.number` instead of `random.number` 

Since 5.5.0, `datatype` replaces `random` in faker

[About datatype in the faker docs](https://fakerjs.dev/api/datatype.html)