### PR TITLE
fix: amend deprecated faker method

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "yaml-lint": "^1.2.4"
   },
   "dependencies": {
-    "@faker-js/faker": "^7.0.0",
+    "@faker-js/faker": ">=7.4.0",
     "chai": "^4.2.0",
     "chalk": "^4.0.0",
     "class-transformer": "^0.5.0",

--- a/src/parsers/FakerParser.ts
+++ b/src/parsers/FakerParser.ts
@@ -15,7 +15,7 @@ export class FakerParser implements IParser {
         if (fixture?.locale) {
             faker.locale = fixture.locale;
         }
-        const result = faker.fake(value);
+        const result = faker.helpers.fake(value);
 
         if ((+result).toString() === result) {
             return +result;

--- a/yarn.lock
+++ b/yarn.lock
@@ -366,10 +366,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@^7.0.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.3.0.tgz#a508df35ded585c4e071cb5d9d7c89623c837fae"
-  integrity sha512-1W0PZezq2rxlAssoWemi9gFRD8IQxvf0FPL5Km3TOmGHFG7ib0TbFBJ0yC7D/1NsxunjNTK6WjUXV8ao/mKZ5w==
+"@faker-js/faker@>=7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-7.4.0.tgz#cac720d860a89d487b47e55e66a4fd114f1d3fe5"
+  integrity sha512-xDd3Tvkt2jgkx1LkuwwxpNBy/Oe+LkZBTwkgEFTiWpVSZgQ5sc/LenbHKRHbFl0dq/KFeeq/szyyPtpJRKY0fg==
 
 "@gerhobbelt/linewrap@0.2.2-3":
   version "0.2.2-3"


### PR DESCRIPTION
Replace `faker.fake` with `faker.helpers.fake`

In the [documentation](https://fakerjs.dev/api/fake.html) the method `faker.fake` appears as deprecated and implemented in this [PR](https://github.com/faker-js/faker/pull/1161).

FIX RobinCK/typeorm-fixtures#200
