### PR TITLE
fix: glob path separator must use '/' on Windows (#203)

### DIFF
--- a/src/Loader.ts
+++ b/src/Loader.ts
@@ -30,7 +30,12 @@ export class Loader {
 
             files = [fixturesPath];
         } else {
-            files = glob.sync(path.resolve(path.join(fixturesPath, `*.{${extensions}}`)));
+            files = glob.sync(
+                path
+                    .resolve(path.join(fixturesPath, `*.{${extensions}}`))
+                    .split(path.sep)
+                    .join('/'),
+            );
         }
 
         for (const file of files) {


### PR DESCRIPTION
- Issue #203

Path passed to glob.sync must explicitly use `/` instead of `\` due to glob 7.x -> 8.x changes as described in the issue.