### PR TITLE
ci(github actions): configure build ci for multiplatform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build CI
 
 on:
   push:
-    branches: [master, develop]
+    branches: [master]
   pull_request:
     branches: [master, develop]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,16 +5,16 @@ name: Build CI
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master, develop]
+    branches: [ master, develop ]
 
 jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        node-version: [14, 16]
+        os: [ ubuntu-latest, windows-latest ]
+        node-version: [ 14, 16 ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,27 +5,29 @@ name: Build CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master, develop ]
+    branches: [master, develop]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
-        node-version: [ 14, 16 ]
+        os: [ubuntu-latest, windows-latest]
+        node-version: [14, 16]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: yarn install
-    - run: yarn lint
-    - run: sudo chmod -R 777 ./dist
-    - run: yarn build
-    - run: yarn test
-      env:
-        CI: true
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn install
+      - run: yarn lint
+      - run: sudo chmod -R 777 ./dist
+        if: contains(matrix.os, 'windows') == false
+      - run: yarn build
+      - run: yarn test
+        env:
+          CI: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - if: contains(matrix.os, 'windows')
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ name: Build CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
     branches: [master, develop]
 


### PR DESCRIPTION
Linking Issues/PRs

- #203 
- #204 

This improves reliability by making it to be able to catch platform-specific bugs.

In the test CI of this changes in my fork repo, it clearly reproduces #203.
https://github.com/kkent030315/typeorm-fixtures/actions/runs/3368028319/jobs/5586113197