### PR TITLE
feat: add disableFaker option to preserve literal {{}} expressions in fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,26 @@ items:
         - foo
 ```
 
+#### Disabling Faker
+
+If you need to use literal `{{...}}` in your fixtures (e.g., for Handlebars templates), you can disable Faker processing:
+
+**Per fixture:**
+```yaml
+entity: EmailTemplate
+disableFaker: true
+items:
+  welcome:
+    subject: 'Welcome {{firstName}}'
+    body: 'Hello {{firstName}} {{lastName}}, welcome to {{companyName}}'
+```
+
+**Globally:**
+```typescript
+const parser = new Parser({ disableFaker: true });
+const builder = new Builder(dataSource, parser, false);
+```
+
 ### EJS templating
 
 This library integrates with the [EJS](https://github.com/mde/ejs)

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,10 +1,13 @@
 import * as parsers from './parsers';
-import { IDataParser, IFixture, IParser } from './interface';
+import { IDataParser, IFixture, IParser, IParserOptions } from './interface';
+import { FakerParser } from './parsers/FakerParser';
 
 export class Parser implements IDataParser {
     private parsers: IParser[] = [];
+    private options: IParserOptions;
 
-    constructor() {
+    constructor(options?: IParserOptions) {
+        this.options = options || {};
         for (const parser of Object.values(parsers)) {
             this.parsers.push(new (parser as any)());
         }
@@ -27,6 +30,10 @@ export class Parser implements IDataParser {
             /* istanbul ignore else */
             if (typeof value === 'string') {
                 for (const parser of this.parsers.sort((a, b) => b.priority - a.priority)) {
+                    // Skip FakerParser if disableFaker is set to true at fixture or global level
+                    if ((fixture.disableFaker || this.options.disableFaker) && parser instanceof FakerParser) {
+                        continue;
+                    }
                     if (parser.isSupport(value)) {
                         entityRawData[key] = parser.parse(value, fixture, entities);
                     }

--- a/src/Resolver.ts
+++ b/src/Resolver.ts
@@ -11,7 +11,7 @@ export class Resolver {
      * @return {IFixture[]}
      */
     resolve(fixtureConfigs: IFixturesConfig[]): IFixture[] {
-        for (const { entity, items, parameters, processor, resolvedFields } of fixtureConfigs) {
+        for (const { entity, items, parameters, processor, resolvedFields, disableFaker, locale } of fixtureConfigs) {
             for (const [mainReferenceName, propertyList] of Object.entries(items)) {
                 const rangeRegExp = /^([\w-_]+)\{(\d+)\.\.(\d+)}$/gm;
                 let referenceNames: string[] = [];
@@ -38,6 +38,8 @@ export class Resolver {
                         entity: entity,
                         name: name,
                         resolvedFields,
+                        disableFaker,
+                        locale,
                         data,
                         dependencies: this.resolveDependencies(name, data),
                     });

--- a/src/interface/IFixture.ts
+++ b/src/interface/IFixture.ts
@@ -2,6 +2,7 @@ export interface IFixture {
     parameters: { [key: string]: any };
     processor?: string;
     locale?: string;
+    disableFaker?: boolean;
     entity: string;
     name: string;
     dependencies: string[];

--- a/src/interface/IFixturesConfig.ts
+++ b/src/interface/IFixturesConfig.ts
@@ -4,5 +4,6 @@ export interface IFixturesConfig {
     parameters?: { [key: string]: any };
     processor?: string;
     resolvedFields?: string[];
+    disableFaker?: boolean;
     items: { [key: string]: any };
 }

--- a/src/interface/IParserOptions.ts
+++ b/src/interface/IParserOptions.ts
@@ -1,0 +1,3 @@
+export interface IParserOptions {
+    disableFaker?: boolean;
+}

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -4,4 +4,5 @@ export * from './IFixture';
 export * from './IFixturesConfig';
 export * from './ILoader';
 export * from './IParser';
+export * from './IParserOptions';
 export * from './IProcessor';

--- a/src/schema/jFixturesSchema.ts
+++ b/src/schema/jFixturesSchema.ts
@@ -51,5 +51,6 @@ export const jFixturesSchema = Joi.object().keys({
     parameters: Joi.object(),
     processor: Joi.string(),
     resolvedFields: Joi.array().items(Joi.string()),
+    disableFaker: Joi.boolean(),
     items: Joi.object().required(),
 });

--- a/test/unit/Parser.test.ts
+++ b/test/unit/Parser.test.ts
@@ -100,4 +100,43 @@ describe('Parser', () => {
             ),
         ).to.deep.equal({ prop: { value: null } });
     });
+
+    it('should not parse faker expressions when disableFaker is true', () => {
+        const parser = new Parser();
+
+        expect(
+            parser.parse(
+                { template: '{{name.firstName}} {{name.lastName}}' },
+                {
+                    parameters: {},
+                    entity: 'test',
+                    name: 'name',
+                    dependencies: [],
+                    disableFaker: true,
+                    data: {},
+                },
+                {},
+            ),
+        ).to.deep.equal({ template: '{{name.firstName}} {{name.lastName}}' });
+    });
+
+    it('should parse faker expressions when disableFaker is false', () => {
+        const parser = new Parser();
+
+        const result = parser.parse(
+            { greeting: 'Hello {{name.firstName}}' },
+            {
+                parameters: {},
+                entity: 'test',
+                name: 'name',
+                dependencies: [],
+                disableFaker: false,
+                data: {},
+            },
+            {},
+        );
+
+        expect(result.greeting).to.not.equal('Hello {{name.firstName}}');
+        expect(result.greeting).to.include('Hello ');
+    });
 });


### PR DESCRIPTION
## Description

This PR adds a `disableFaker` option to allow preserving literal `{{...}}` expressions in fixtures without Faker processing them. This is useful when fixtures contain template syntax (e.g., Handlebars templates) that conflicts with Faker's syntax.

## Problem

Currently, any string containing `{{...}}` in fixtures is automatically processed by Faker. This causes issues when users need to store actual template strings that use the same syntax.

Example:
```yaml
  entity: EmailTemplate
  items:
    welcome:
      subject: "Welcome {{firstName}}"  # This gets processed by Faker
```
##  Solution

Added a disableFaker boolean option that can be set at:
  1. Fixture level - in YAML/JSON fixture files
  2. Global level - when creating the Parser instance

When disableFaker is true, the FakerParser is skipped, preserving literal {{...}} expressions.

##  Usage

### Per Fixture
```yaml
  entity: EmailTemplate
  disableFaker: true
  items:
    welcome:
      subject: "Welcome {{firstName}}"  # Preserved as literal string
```

### Globally
```typescript
  const parser = new Parser({ disableFaker: true });
  const builder = new Builder(dataSource, parser, false);
```

## Changes

  - Added disableFaker?: boolean to IFixturesConfig and IFixture interfaces
  - Created IParserOptions interface for Parser configuration
  - Updated Parser class to accept options and skip FakerParser when disabled
  - Updated Resolver to pass the disableFaker flag through fixtures
  - Added tests to verify the functionality
  - Updated README.md with documentation

 ## Testing

  - Added 2 tests to test/unit/Parser.test.ts verifying faker expressions are preserved when disabled
  - All existing tests pass
  - Fully backward compatible - no breaking changes

  Related Issues

  This feature helps users who need to store template strings (Handlebars, Mustache, etc.) in their fixtures without having them processed as Faker expressions.